### PR TITLE
30 to 50

### DIFF
--- a/runscope2slack.py
+++ b/runscope2slack.py
@@ -12,7 +12,7 @@ runscope_bucket = os.environ.get('RUNSCOPE_BUCKET')
 slacktoken = os.environ.get('SLACK_TOKEN')
 sc = SlackClient(slacktoken)
 
-skiptitles = ['WF default domain 10 minute','WF t2medium domain 10 minute']
+skiptitles = ['Core WF default domain','Core WF t2medium domain']
 
 def run():
 
@@ -68,7 +68,7 @@ def run():
 		d = ImageDraw.Draw(img)
 		r = 0
 		c = 0
-		for dat in data:
+		for dat in sorted(data, key = lambda i: i['label']):
 			print dat['label']
 			print dat[period]
 			if dat[period] < red_threshold:

--- a/runscope2slack.py
+++ b/runscope2slack.py
@@ -17,7 +17,7 @@ skiptitles = ['WF default domain 10 minute','WF t2medium domain 10 minute']
 def run():
 
 	# get list of all tests:
-	url = 'https://api.runscope.com/buckets/%s/tests?count=30' % (runscope_bucket)
+	url = 'https://api.runscope.com/buckets/%s/tests?count=50' % (runscope_bucket)
 	r = requests.get(url,headers=headers)
 
 	tests = [{'name': test['name'], 'id':test['id']} for test in r.json()['data']]


### PR DESCRIPTION
In runscope2slack.py: Changed max tests from 30 to 50. Corrected the titles in the skiptitles. Added sorting to the results (so they show up in the same order each time). In deploy.zip: Added the updated runscope2slack.py.